### PR TITLE
Export AtomicFloat32 to allow casting numbers with possible integer value

### DIFF
--- a/src/atomic/float32.js
+++ b/src/atomic/float32.js
@@ -1,4 +1,4 @@
-import { isFloat } from '../common/utils'
+import { isFloat, isInt } from '../common/utils'
 
 import Atomic from '../atomic'
 
@@ -11,8 +11,8 @@ export default class AtomicFloat32 extends Atomic {
    * @param {number} [value] Float number
    */
   constructor(value) {
-    if (value && !isFloat(value)) {
-      throw new Error('OSC AtomicFloat32 constructor expects value of type float')
+    if (value && !isFloat(value) && !isInt(value)) {
+      throw new Error('OSC AtomicFloat32 constructor expects value of type float or integer')
     }
 
     super(value)

--- a/src/common/helpers.js
+++ b/src/common/helpers.js
@@ -6,6 +6,7 @@ import {
   isString,
 } from './utils'
 
+import AtomicFloat32 from '../atomic/float32'
 /**
  * Checks type of given object and returns the regarding OSC
  * Type tag character
@@ -15,7 +16,7 @@ import {
 export function typeTag(item) {
   if (isInt(item)) {
     return 'i'
-  } else if (isFloat(item)) {
+  } else if (isFloat(item) || item instanceof AtomicFloat32) {
     return 'f'
   } else if (isString(item)) {
     return 's'

--- a/src/message.js
+++ b/src/message.js
@@ -95,6 +95,8 @@ export default class Message {
           argument = new AtomicString(value)
         } else if (isBlob(value)) {
           argument = new AtomicBlob(value)
+        } else if (value instanceof AtomicFloat32) {
+          argument = value
         } else {
           throw new Error('OSC Message found unknown argument type')
         }

--- a/src/osc.js
+++ b/src/osc.js
@@ -5,6 +5,7 @@ import {
   isString,
 } from './common/utils'
 
+import AtomicFloat32 from './atomic/float32'
 import Bundle from './bundle'
 import EventHandler from './events'
 import Message from './message'
@@ -244,6 +245,8 @@ class OSC {
 
 // expose status flags
 OSC.STATUS = STATUS
+
+OSC.AtomicFloat32 = AtomicFloat32
 
 // expose OSC classes
 OSC.Packet = Packet

--- a/test/atomic.spec.js
+++ b/test/atomic.spec.js
@@ -61,4 +61,12 @@ describe('Atomic', () => {
       })
     })
   })
+
+  describe('value types', () => {
+    it('able to create float32 with round values', () => {
+      expect(() => new AtomicFloat32(0.0)).to.not.throw()
+      expect(() => new AtomicFloat32(1.0)).to.not.throw()
+      expect(() => new AtomicFloat32(2.0)).to.not.throw()
+    })
+  })
 })


### PR DESCRIPTION
I have a situation where certain message arguments need to be always sent as `float32`. However, when the values hit round numbers (0, 1.0, 2.0..) they get sent as `int32`.

This PR exports `OSC.AtomicFloat32` to allow force-casting values to float32. Also added support for this in functions where the value need to be passed through.

Example use case:
```js
new Message('/route', new AtomicFloat32(i / 2))
```
