### PR TITLE
Pass remote address information from UDP Datagram socket

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,6 +6,7 @@
   "parser": "babel-eslint",
   "extends": "airbnb-base",
   "rules": {
+    "max-classes-per-file": "off",
     "class-methods-use-this": "off",
     "comma-dangle": [
       "error",

--- a/src/events.js
+++ b/src/events.js
@@ -37,7 +37,7 @@ export default class EventHandler {
      * @type {object} options
      * @private
      */
-    this.options = Object.assign({}, defaultOptions, options)
+    this.options = { ...defaultOptions, ...options }
     /**
      * @type {array} addressHandlers
      * @private

--- a/src/events.js
+++ b/src/events.js
@@ -63,7 +63,7 @@ export default class EventHandler {
    * Internally used method to dispatch OSC Packets. Extracts
    * given Timetags and dispatches them accordingly
    * @param {Packet} packet
-   * @param {*} [rinfo] Remove address info
+   * @param {*} [rinfo] Remote address info
    * @return {boolean} Success state
    * @private
    */
@@ -110,7 +110,7 @@ export default class EventHandler {
    * expression pattern matching for OSC addresses
    * @param {string} name OSC address or event name
    * @param {*} [data] The data of the event
-   * @param {*} [rinfo] Remove address info
+   * @param {*} [rinfo] Remote address info
    * @return {boolean} Success state
    * @private
    */

--- a/src/events.js
+++ b/src/events.js
@@ -63,6 +63,7 @@ export default class EventHandler {
    * Internally used method to dispatch OSC Packets. Extracts
    * given Timetags and dispatches them accordingly
    * @param {Packet} packet
+   * @param {*} [rinfo] Remove address info
    * @return {boolean} Success state
    * @private
    */
@@ -109,6 +110,7 @@ export default class EventHandler {
    * expression pattern matching for OSC addresses
    * @param {string} name OSC address or event name
    * @param {*} [data] The data of the event
+   * @param {*} [rinfo] Remove address info
    * @return {boolean} Success state
    * @private
    */
@@ -176,6 +178,7 @@ export default class EventHandler {
    * (any type). All regarding listeners will be notified with this data.
    * As a third argument you can define a javascript timestamp (number or
    * Date instance) for timed notification of the listeners.
+   * @param {*} [rinfo] Remote address info
    * @return {boolean} Success state of notification
    *
    * @example

--- a/src/events.js
+++ b/src/events.js
@@ -66,7 +66,7 @@ export default class EventHandler {
    * @return {boolean} Success state
    * @private
    */
-  dispatch(packet) {
+  dispatch(packet, rinfo) {
     if (!(packet instanceof Packet)) {
       throw new Error('OSC EventHander dispatch() accepts only arguments of type Packet')
     }
@@ -97,7 +97,7 @@ export default class EventHandler {
       })
     } else if (packet.value instanceof Message) {
       const message = packet.value
-      return this.notify(message.address, message)
+      return this.notify(message.address, message, 0, rinfo)
     }
 
     throw new Error('OSC EventHander dispatch() can\'t dispatch unknown Packet value')
@@ -204,7 +204,7 @@ export default class EventHandler {
     if (args[0] instanceof Packet) {
       return this.dispatch(args[0])
     } else if (args[0] instanceof Bundle || args[0] instanceof Message) {
-      return this.dispatch(new Packet(args[0]))
+      return this.dispatch(new Packet(args[0]), args[1])
     } else if (!isString(args[0])) {
       const packet = new Packet()
       packet.unpack(dataView(args[0]))

--- a/src/message.js
+++ b/src/message.js
@@ -49,7 +49,7 @@ export default class Message {
       }
 
       this.address = prepareAddress(args.shift())
-      this.types = args.map(item => typeTag(item)).join('')
+      this.types = args.map((item) => typeTag(item)).join('')
       this.args = args
     }
   }

--- a/src/osc.js
+++ b/src/osc.js
@@ -86,7 +86,7 @@ class OSC {
      * @type {object} options
      * @private
      */
-    this.options = Object.assign({}, defaultOptions, options)
+    this.options = { ...defaultOptions, ...options }
     /**
      * @type {EventHandler} eventHandler
      * @private

--- a/src/plugin/bridge.js
+++ b/src/plugin/bridge.js
@@ -168,9 +168,9 @@ export default class BridgePlugin {
       })
 
       this.websocket.on('connection', (client) => {
-        client.on('message', (message) => {
+        client.on('message', (message, rinfo) => {
           this.send(message, { receiver: 'udp' })
-          this.notify(new Uint8Array(message))
+          this.notify(new Uint8Array(message), rinfo)
         })
       })
     })

--- a/src/plugin/bridge.js
+++ b/src/plugin/bridge.js
@@ -39,11 +39,14 @@ const defaultOptions = {
  * @private
  */
 function mergeOptions(base, custom) {
-  return Object.assign({}, defaultOptions, base, custom, {
-    udpServer: Object.assign({}, defaultOptions.udpServer, base.udpServer, custom.udpServer),
-    udpClient: Object.assign({}, defaultOptions.udpClient, base.udpClient, custom.udpClient),
-    wsServer: Object.assign({}, defaultOptions.wsServer, base.wsServer, custom.wsServer),
-  })
+  return {
+    ...defaultOptions,
+    ...base,
+    ...custom,
+    udpServer: { ...defaultOptions.udpServer, ...base.udpServer, ...custom.udpServer },
+    udpClient: { ...defaultOptions.udpClient, ...base.udpClient, ...custom.udpClient },
+    wsServer: { ...defaultOptions.wsServer, ...base.wsServer, ...custom.wsServer },
+  }
 }
 
 /**

--- a/src/plugin/dgram.js
+++ b/src/plugin/dgram.js
@@ -46,10 +46,13 @@ const defaultOptions = {
  * @private
  */
 function mergeOptions(base, custom) {
-  return Object.assign({}, defaultOptions, base, custom, {
-    open: Object.assign({}, defaultOptions.open, base.open, custom.open),
-    send: Object.assign({}, defaultOptions.send, base.send, custom.send),
-  })
+  return {
+    ...defaultOptions,
+    ...base,
+    ...custom,
+    open: { ...defaultOptions.open, ...base.open, ...custom.open },
+    send: { ...defaultOptions.send, ...base.send, ...custom.send },
+  }
 }
 
 /**
@@ -136,7 +139,7 @@ export default class DatagramPlugin {
    * @param {boolean} [customOptions.exclusive=false] Exclusive flag
    */
   open(customOptions = {}) {
-    const options = Object.assign({}, this.options.open, customOptions)
+    const options = { ...this.options.open, ...customOptions }
     const { port, exclusive } = options
 
     this.socketStatus = STATUS.IS_CONNECTING
@@ -173,7 +176,7 @@ export default class DatagramPlugin {
    * @param {number} [customOptions.port] Port of udp client
    */
   send(binary, customOptions = {}) {
-    const options = Object.assign({}, this.options.send, customOptions)
+    const options = { ...this.options.send, ...customOptions }
     const { port, host } = options
 
     this.socket.send(Buffer.from(binary), 0, binary.byteLength, port, host)

--- a/src/plugin/dgram.js
+++ b/src/plugin/dgram.js
@@ -95,8 +95,8 @@ export default class DatagramPlugin {
     this.socketStatus = STATUS.IS_NOT_INITIALIZED
 
     // register events
-    this.socket.on('message', (message) => {
-      this.notify(message)
+    this.socket.on('message', (message, rinfo) => {
+      this.notify(message, rinfo)
     })
 
     this.socket.on('error', (error) => {

--- a/src/plugin/wsclient.js
+++ b/src/plugin/wsclient.js
@@ -49,7 +49,7 @@ export default class WebsocketClientPlugin {
      * @type {object} options
      * @private
      */
-    this.options = Object.assign({}, defaultOptions, customOptions)
+    this.options = { ...defaultOptions, ...customOptions}
 
     /**
      * @type {object} socket
@@ -95,7 +95,7 @@ export default class WebsocketClientPlugin {
    * @param {boolean} [customOptions.secure] Use wss:// for secure connections
    */
   open(customOptions = {}) {
-    const options = Object.assign({}, this.options, customOptions)
+    const options = { ...this.options, ...customOptions}
     const { port, host, secure } = options
 
     // close socket when already given
@@ -105,6 +105,13 @@ export default class WebsocketClientPlugin {
 
     // create websocket client
     const protocol = secure ? 'wss' : 'ws'
+    const rinfo = {
+      address: host,
+      family: protocol,
+      port,
+      size: 0,
+    }
+
     this.socket = new WebSocket(`${protocol}://${host}:${port}`)
     this.socket.binaryType = 'arraybuffer'
     this.socketStatus = STATUS.IS_CONNECTING
@@ -125,7 +132,7 @@ export default class WebsocketClientPlugin {
     }
 
     this.socket.onmessage = (message) => {
-      this.notify(message.data)
+      this.notify(message.data, rinfo)
     }
   }
 

--- a/src/plugin/wsclient.js
+++ b/src/plugin/wsclient.js
@@ -49,7 +49,7 @@ export default class WebsocketClientPlugin {
      * @type {object} options
      * @private
      */
-    this.options = { ...defaultOptions, ...customOptions}
+    this.options = { ...defaultOptions, ...customOptions }
 
     /**
      * @type {object} socket
@@ -95,7 +95,7 @@ export default class WebsocketClientPlugin {
    * @param {boolean} [customOptions.secure] Use wss:// for secure connections
    */
   open(customOptions = {}) {
-    const options = { ...this.options, ...customOptions}
+    const options = { ...this.options, ...customOptions }
     const { port, host, secure } = options
 
     // close socket when already given

--- a/src/plugin/wsserver.js
+++ b/src/plugin/wsserver.js
@@ -47,7 +47,7 @@ export default class WebsocketServerPlugin {
      * @type {object} options
      * @private
      */
-    this.options = Object.assign({}, defaultOptions, customOptions)
+    this.options = { ...defaultOptions, ...customOptions }
 
     /**
      * @type {object} socket
@@ -92,7 +92,7 @@ export default class WebsocketServerPlugin {
    * @param {number} [customOptions.port] Port of Websocket server
    */
   open(customOptions = {}) {
-    const options = Object.assign({}, this.options, customOptions)
+    const options = { ...this.options, ...customOptions }
     const { port, host } = options
     const rinfo = {
       address: host,

--- a/src/plugin/wsserver.js
+++ b/src/plugin/wsserver.js
@@ -94,6 +94,12 @@ export default class WebsocketServerPlugin {
   open(customOptions = {}) {
     const options = Object.assign({}, this.options, customOptions)
     const { port, host } = options
+    const rinfo = {
+      address: host,
+      family: 'wsserver',
+      port,
+      size: 0,
+    }
 
     // close socket when already given
     if (this.socket) {
@@ -117,7 +123,7 @@ export default class WebsocketServerPlugin {
 
     this.socket.on('connection', (client) => {
       client.on('message', (message) => {
-        this.notify(new Uint8Array(message))
+        this.notify(new Uint8Array(message), rinfo)
       })
     })
   }

--- a/test/plugin/bridge.spec.js
+++ b/test/plugin/bridge.spec.js
@@ -1,24 +1,55 @@
 import { expect } from 'chai'
 
+import OSC from '../../src/osc'
+import Message from '../../src/message'
+
 import BridgePlugin from '../../src/plugin/bridge'
+import DatagramPlugin from '../../src/plugin/dgram'
+import WebsocketClientPlugin from '../../src/plugin/wsclient'
+
+const wsPort = 9129
+const udpPort = 9130
 
 /** @test {BridgePlugin} */
 describe('BridgePlugin', () => {
   let plugin
+  let osc
+  let oscWsClient
+  let oscUdpClient
 
   before(() => {
     plugin = new BridgePlugin({
       wsServer: {
-        port: 8129,
+        port: wsPort,
       },
       udpServer: {
         host: '127.0.0.1',
+        port: udpPort,
       },
+    })
+
+    osc = new OSC({
+      plugin,
+    })
+
+    oscWsClient = new OSC({
+      plugin: new WebsocketClientPlugin({
+        port: wsPort,
+      })
+    })
+
+    oscUdpClient = new OSC({
+      plugin: new DatagramPlugin({
+        send: {
+          host: '127.0.0.1',
+          port: udpPort,
+        }
+      })
     })
   })
 
   it('merges the given options correctly', () => {
-    expect(plugin.options.wsServer.port).to.be.equals(8129)
+    expect(plugin.options.wsServer.port).to.be.equals(wsPort)
     expect(plugin.options.udpServer.host).to.be.equals('127.0.0.1')
     expect(plugin.options.receiver).to.be.equals('ws')
   })
@@ -27,5 +58,44 @@ describe('BridgePlugin', () => {
     it('returns the initial status', () => {
       expect(plugin.status()).to.be.equals(-1)
     })
+  })
+
+
+  describe('remote address info', () => {
+    it('returns the remote address info', () => new Promise((resolve, reject) => {
+
+      let resolved = false
+
+      const expectedMessage = {
+        offset: 24,
+        address: '/test/path',
+        types: ',ii',
+        args: [122, 554]
+      }
+
+      const expectedRinfo = {
+        address: '127.0.0.1',
+        family: 'ws',
+        port: wsPort,
+        size: 0,
+      }
+
+      osc.open()
+
+      oscWsClient.open()
+      oscUdpClient.open()
+
+      oscUdpClient.on('/test/path', (message, rinfo) => {
+        expect(message).to.deep.equal(expectedMessage)
+        expect(rinfo).to.deep.equal(expectedRinfo)
+
+        resolve()
+        resolved = true
+      })
+
+      oscWsClient.on('open', () => oscWsClient.send(new Message('/test/path', 122, 554)))
+
+      setTimeout(() => !resolved && reject(new Error('Timeout')), 1000)
+    }))
   })
 })

--- a/test/plugin/bridge.spec.js
+++ b/test/plugin/bridge.spec.js
@@ -64,7 +64,7 @@ describe('BridgePlugin', () => {
   describe('remote address info', () => {
     it('returns the remote address info', () => new Promise((resolve, reject) => {
 
-      let resolved = false
+      let timer
 
       const expectedMessage = {
         offset: 24,
@@ -89,13 +89,13 @@ describe('BridgePlugin', () => {
         expect(message).to.deep.equal(expectedMessage)
         expect(rinfo).to.deep.equal(expectedRinfo)
 
+        timer = null
         resolve()
-        resolved = true
       })
 
       oscWsClient.on('open', () => oscWsClient.send(new Message('/test/path', 122, 554)))
 
-      setTimeout(() => !resolved && reject(new Error('Timeout')), 1000)
+      timer = setTimeout(() => reject(new Error('Timeout')), 1000)
     }))
   })
 })

--- a/test/plugin/dgram.spec.js
+++ b/test/plugin/dgram.spec.js
@@ -41,8 +41,6 @@ describe('DatagramPlugin', () => {
   describe('remote address info', () => {
     it('returns the remote address info', () => new Promise((resolve, reject) => {
 
-      let message
-      let rinfo
       let resolved = false
 
       const expectedMessage = {
@@ -60,10 +58,7 @@ describe('DatagramPlugin', () => {
       }
 
       osc.open()
-      osc.on('/test/path', (a, b) => {
-        message = a
-        rinfo = b
-
+      osc.on('/test/path', (message, rinfo) => {
         expect(message).to.deep.equal(expectedMessage)
         expect(rinfo).to.deep.equal(expectedRinfo)
 

--- a/test/plugin/dgram.spec.js
+++ b/test/plugin/dgram.spec.js
@@ -1,9 +1,10 @@
 import { expect } from 'chai'
 
-import OSC from '../../src/osc'
-import Message from '../../src/message'
-
 import DatagramPlugin from '../../src/plugin/dgram'
+import Message from '../../src/message'
+import OSC from '../../src/osc'
+
+const PORT_UDP = 8129
 
 /** @test {DatagramPlugin} */
 describe('DatagramPlugin', () => {
@@ -13,11 +14,11 @@ describe('DatagramPlugin', () => {
   before(() => {
     plugin = new DatagramPlugin({
       send: {
-        port: 8129,
+        port: PORT_UDP,
       },
       open: {
         host: '127.0.0.1',
-        port: 8129,
+        port: PORT_UDP,
       },
     })
 
@@ -28,7 +29,7 @@ describe('DatagramPlugin', () => {
   })
 
   it('merges the given options correctly', () => {
-    expect(plugin.options.send.port).to.be.equals(8129)
+    expect(plugin.options.send.port).to.be.equals(PORT_UDP)
     expect(plugin.options.open.host).to.be.equals('127.0.0.1')
   })
 
@@ -39,36 +40,31 @@ describe('DatagramPlugin', () => {
   })
 
   describe('remote address info', () => {
-    it('returns the remote address info', () => new Promise((resolve, reject) => {
-
-      let timer
-
+    it('returns the remote address info', (done) => {
       const expectedMessage = {
         offset: 24,
         address: '/test/path',
         types: ',ii',
-        args: [ 122, 554 ]
+        args: [122, 554],
       }
 
       const expectedRinfo = {
         address: '127.0.0.1',
         family: 'IPv4',
-        port: 8129,
+        port: PORT_UDP,
         size: 24,
       }
 
       osc.open()
+
       osc.on('/test/path', (message, rinfo) => {
         expect(message).to.deep.equal(expectedMessage)
         expect(rinfo).to.deep.equal(expectedRinfo)
 
-        timer = null
-        resolve()
+        done()
       })
 
       osc.send(new Message('/test/path', 122, 554))
-
-      timer = setTimeout(() => reject(new Error('Timeout')), 1000)
-    }))
+    })
   })
 })

--- a/test/plugin/dgram.spec.js
+++ b/test/plugin/dgram.spec.js
@@ -1,9 +1,9 @@
-import chai, { expect } from 'chai'
+import { expect } from 'chai'
 
 import OSC from '../../src/osc'
-import DatagramPlugin from '../../src/plugin/dgram'
 import Message from '../../src/message'
 
+import DatagramPlugin from '../../src/plugin/dgram'
 
 /** @test {DatagramPlugin} */
 describe('DatagramPlugin', () => {
@@ -37,7 +37,6 @@ describe('DatagramPlugin', () => {
       expect(plugin.status()).to.be.equals(-1)
     })
   })
-
 
   describe('remote address info', () => {
     it('returns the remote address info', () => new Promise((resolve, reject) => {
@@ -74,7 +73,7 @@ describe('DatagramPlugin', () => {
 
       osc.send(new Message('/test/path', 122, 554))
 
-      setTimeout(() => !resolved && reject(), 1000)
+      setTimeout(() => !resolved && reject(new Error('Timeout')), 1000)
     }))
   })
 })

--- a/test/plugin/dgram.spec.js
+++ b/test/plugin/dgram.spec.js
@@ -1,10 +1,14 @@
-import { expect } from 'chai'
+import chai, { expect } from 'chai'
 
+import OSC from '../../src/osc'
 import DatagramPlugin from '../../src/plugin/dgram'
+import Message from '../../src/message'
+
 
 /** @test {DatagramPlugin} */
 describe('DatagramPlugin', () => {
   let plugin
+  let osc
 
   before(() => {
     plugin = new DatagramPlugin({
@@ -13,7 +17,13 @@ describe('DatagramPlugin', () => {
       },
       open: {
         host: '127.0.0.1',
+        port: 8129,
       },
+    })
+
+    osc = new OSC({
+      discardLateMessages: true,
+      plugin,
     })
   })
 
@@ -26,5 +36,45 @@ describe('DatagramPlugin', () => {
     it('returns the initial status', () => {
       expect(plugin.status()).to.be.equals(-1)
     })
+  })
+
+
+  describe('remote address info', () => {
+    it('returns the remote address info', () => new Promise((resolve, reject) => {
+
+      let message
+      let rinfo
+      let resolved = false
+
+      const expectedMessage = {
+        offset: 24,
+        address: '/test/path',
+        types: ',ii',
+        args: [ 122, 554 ]
+      }
+
+      const expectedRinfo = {
+        address: '127.0.0.1',
+        family: 'IPv4',
+        port: 8129,
+        size: 24,
+      }
+
+      osc.open()
+      osc.on('/test/path', (a, b) => {
+        message = a
+        rinfo = b
+
+        expect(message).to.deep.equal(expectedMessage)
+        expect(rinfo).to.deep.equal(expectedRinfo)
+
+        resolve()
+        resolved = true
+      })
+
+      osc.send(new Message('/test/path', 122, 554))
+
+      setTimeout(() => !resolved && reject(), 1000)
+    }))
   })
 })

--- a/test/plugin/dgram.spec.js
+++ b/test/plugin/dgram.spec.js
@@ -41,7 +41,7 @@ describe('DatagramPlugin', () => {
   describe('remote address info', () => {
     it('returns the remote address info', () => new Promise((resolve, reject) => {
 
-      let resolved = false
+      let timer
 
       const expectedMessage = {
         offset: 24,
@@ -62,13 +62,13 @@ describe('DatagramPlugin', () => {
         expect(message).to.deep.equal(expectedMessage)
         expect(rinfo).to.deep.equal(expectedRinfo)
 
+        timer = null
         resolve()
-        resolved = true
       })
 
       osc.send(new Message('/test/path', 122, 554))
 
-      setTimeout(() => !resolved && reject(new Error('Timeout')), 1000)
+      timer = setTimeout(() => reject(new Error('Timeout')), 1000)
     }))
   })
 })

--- a/test/plugin/ws.spec.js
+++ b/test/plugin/ws.spec.js
@@ -1,0 +1,70 @@
+import { expect } from 'chai'
+
+import OSC from '../../src/osc'
+import Message from '../../src/message'
+
+import WebsocketClientPlugin from '../../src/plugin/wsclient'
+import WebsocketServerPlugin from '../../src/plugin/wsserver'
+
+/** @test {WebsocketClientPlugin} */
+describe('WebsocketClient/ServerPlugin', () => {
+  let plugin
+  let osc
+  let oscServer
+
+  before(() => {
+    plugin = new WebsocketClientPlugin({
+      port: 8129,
+      host: '127.0.0.1',
+    })
+
+    osc = new OSC({
+      discardLateMessages: true,
+      plugin,
+    })
+
+    oscServer = new OSC({
+      discardLateMessages: true,
+      plugin: new WebsocketServerPlugin({
+        port: 8129,
+        host: '127.0.0.1',
+      }),
+    })
+  })
+
+  describe('remote address info', () => {
+    it('returns the remote address info', () => new Promise((resolve, reject) => {
+
+      let resolved = false
+
+      const expectedMessage = {
+        offset: 24,
+        address: '/test/path',
+        types: ',ii',
+        args: [122, 554]
+      }
+
+      const expectedRinfo = {
+        address: '127.0.0.1',
+        family: 'wsserver',
+        port: 8129,
+        size: 0,
+      }
+
+      oscServer.open()
+      osc.open()
+
+      oscServer.on('/test/path', (message, rinfo) => {
+        expect(message).to.deep.equal(expectedMessage)
+        expect(rinfo).to.deep.equal(expectedRinfo)
+
+        resolve()
+        resolved = true
+      })
+
+      osc.on('open', () => osc.send(new Message('/test/path', 122, 554)))
+
+      setTimeout(() => !resolved && reject(new Error('Timeout')), 1000)
+    }))
+  })
+})

--- a/test/plugin/ws.spec.js
+++ b/test/plugin/ws.spec.js
@@ -6,6 +6,8 @@ import Message from '../../src/message'
 import WebsocketClientPlugin from '../../src/plugin/wsclient'
 import WebsocketServerPlugin from '../../src/plugin/wsserver'
 
+const PORT_WEBSOCKET = 8129
+
 /** @test {WebsocketClientPlugin} */
 describe('WebsocketClient/ServerPlugin', () => {
   let plugin
@@ -14,7 +16,7 @@ describe('WebsocketClient/ServerPlugin', () => {
 
   before(() => {
     plugin = new WebsocketClientPlugin({
-      port: 8129,
+      port: PORT_WEBSOCKET,
       host: '127.0.0.1',
     })
 
@@ -26,45 +28,39 @@ describe('WebsocketClient/ServerPlugin', () => {
     oscServer = new OSC({
       discardLateMessages: true,
       plugin: new WebsocketServerPlugin({
-        port: 8129,
+        port: PORT_WEBSOCKET,
         host: '127.0.0.1',
       }),
     })
   })
 
   describe('remote address info', () => {
-    it('returns the remote address info', () => new Promise((resolve, reject) => {
-
-      let timer
-
+    it('returns the remote address info', (done) => {
       const expectedMessage = {
         offset: 24,
         address: '/test/path',
         types: ',ii',
-        args: [122, 554]
+        args: [122, 554],
       }
 
       const expectedRinfo = {
         address: '127.0.0.1',
         family: 'wsserver',
-        port: 8129,
+        port: PORT_WEBSOCKET,
         size: 0,
       }
-
-      oscServer.open()
-      osc.open()
 
       oscServer.on('/test/path', (message, rinfo) => {
         expect(message).to.deep.equal(expectedMessage)
         expect(rinfo).to.deep.equal(expectedRinfo)
 
-        timer = null
-        resolve()
+        done()
       })
 
       osc.on('open', () => osc.send(new Message('/test/path', 122, 554)))
 
-      timer = setTimeout(() => reject(new Error('Timeout')), 1000)
-    }))
+      oscServer.open()
+      osc.open()
+    })
   })
 })

--- a/test/plugin/ws.spec.js
+++ b/test/plugin/ws.spec.js
@@ -35,7 +35,7 @@ describe('WebsocketClient/ServerPlugin', () => {
   describe('remote address info', () => {
     it('returns the remote address info', () => new Promise((resolve, reject) => {
 
-      let resolved = false
+      let timer
 
       const expectedMessage = {
         offset: 24,
@@ -58,13 +58,13 @@ describe('WebsocketClient/ServerPlugin', () => {
         expect(message).to.deep.equal(expectedMessage)
         expect(rinfo).to.deep.equal(expectedRinfo)
 
+        timer = null
         resolve()
-        resolved = true
       })
 
       osc.on('open', () => osc.send(new Message('/test/path', 122, 554)))
 
-      setTimeout(() => !resolved && reject(new Error('Timeout')), 1000)
+      timer = setTimeout(() => reject(new Error('Timeout')), 1000)
     }))
   })
 })

--- a/test/plugin/wsclient.spec.js
+++ b/test/plugin/wsclient.spec.js
@@ -1,35 +1,15 @@
 import { expect } from 'chai'
 
-import OSC from '../../src/osc'
-import Message from '../../src/message'
-
 import WebsocketClientPlugin from '../../src/plugin/wsclient'
-import WebsocketServerPlugin from '../../src/plugin/wsserver'
 
 /** @test {WebsocketClientPlugin} */
 describe('WebsocketClientPlugin', () => {
   let plugin
-  let osc
-  let oscServer
-  let oscBridge
 
   before(() => {
     plugin = new WebsocketClientPlugin({
       port: 8129,
       host: '127.0.0.1',
-    })
-
-    osc = new OSC({
-      discardLateMessages: true,
-      plugin,
-    })
-
-    oscServer = new OSC({
-      discardLateMessages: true,
-      plugin: new WebsocketServerPlugin({
-        port: 8129,
-        host: '127.0.0.1',
-      }),
     })
   })
 
@@ -43,47 +23,5 @@ describe('WebsocketClientPlugin', () => {
     it('returns the initial status', () => {
       expect(plugin.status()).to.be.equals(-1)
     })
-  })
-
-
-  describe('remote address info', () => {
-    it('returns the remote address info', () => new Promise((resolve, reject) => {
-
-      let message
-      let rinfo
-      let resolved = false
-
-      const expectedMessage = {
-        offset: 24,
-        address: '/test/path',
-        types: ',ii',
-        args: [ 122, 554 ]
-      }
-
-      const expectedRinfo = {
-        address: '127.0.0.1',
-        family: 'IPv4',
-        port: 8129,
-        size: 24,
-      }
-
-      oscServer.open()
-      osc.open()
-
-      oscServer.on('/test/path', (a, b) => {
-        message = a
-        rinfo = b
-
-        expect(message).to.deep.equal(expectedMessage)
-        expect(rinfo).to.deep.equal(expectedRinfo)
-
-        resolve()
-        resolved = true
-      })
-
-      osc.on('open', () => osc.send(new Message('/test/path', 122, 554)))
-
-      setTimeout(() => !resolved && reject(new Error('Timeout')), 1000)
-    }))
   })
 })

--- a/test/plugin/wsclient.spec.js
+++ b/test/plugin/wsclient.spec.js
@@ -1,15 +1,35 @@
 import { expect } from 'chai'
 
+import OSC from '../../src/osc'
+import Message from '../../src/message'
+
 import WebsocketClientPlugin from '../../src/plugin/wsclient'
+import WebsocketServerPlugin from '../../src/plugin/wsserver'
 
 /** @test {WebsocketClientPlugin} */
 describe('WebsocketClientPlugin', () => {
   let plugin
+  let osc
+  let oscServer
+  let oscBridge
 
   before(() => {
     plugin = new WebsocketClientPlugin({
       port: 8129,
       host: '127.0.0.1',
+    })
+
+    osc = new OSC({
+      discardLateMessages: true,
+      plugin,
+    })
+
+    oscServer = new OSC({
+      discardLateMessages: true,
+      plugin: new WebsocketServerPlugin({
+        port: 8129,
+        host: '127.0.0.1',
+      }),
     })
   })
 
@@ -23,5 +43,47 @@ describe('WebsocketClientPlugin', () => {
     it('returns the initial status', () => {
       expect(plugin.status()).to.be.equals(-1)
     })
+  })
+
+
+  describe('remote address info', () => {
+    it('returns the remote address info', () => new Promise((resolve, reject) => {
+
+      let message
+      let rinfo
+      let resolved = false
+
+      const expectedMessage = {
+        offset: 24,
+        address: '/test/path',
+        types: ',ii',
+        args: [ 122, 554 ]
+      }
+
+      const expectedRinfo = {
+        address: '127.0.0.1',
+        family: 'IPv4',
+        port: 8129,
+        size: 24,
+      }
+
+      oscServer.open()
+      osc.open()
+
+      oscServer.on('/test/path', (a, b) => {
+        message = a
+        rinfo = b
+
+        expect(message).to.deep.equal(expectedMessage)
+        expect(rinfo).to.deep.equal(expectedRinfo)
+
+        resolve()
+        resolved = true
+      })
+
+      osc.on('open', () => osc.send(new Message('/test/path', 122, 554)))
+
+      setTimeout(() => !resolved && reject(new Error('Timeout')), 1000)
+    }))
   })
 })


### PR DESCRIPTION

This PR passes remote address information from the `DatagramPlugin` through `EventHandler`. Resolves #28.

Example use:

```
osc.on('*', (message, rinfo) => {
  if (rinfo) console.log('From', `${rinfo.address}:${rinfo.port}`)
  console.log(message)
})
```

Here's the schema:

- `rinfo` <Object> Remote address information.
  - `address` <string> The sender address.
  - `family` <string> The address family ('IPv4' or 'IPv6').
  - `port` <number> The sender port.
  - `size` <number> The message size.

(From: https://nodejs.org/api/dgram.html#dgram_event_message)
