### PR TITLE
WsServer: allow binding to existing HTTP server

### DIFF
--- a/src/plugin/bridge.js
+++ b/src/plugin/bridge.js
@@ -66,11 +66,18 @@ export default class BridgePlugin {
    * @param {number} [options.udpClient.port=41235] Port of udp client for messaging
    * @param {string} [options.wsServer.host='localhost'] Hostname of Websocket server
    * @param {number} [options.wsServer.port=8080] Port of Websocket server
+   * @param {http.Server|https.Server} [options.wsServer.server] Optional: a pre-created Node.js HTTP/S server to be used instead of creating a new one
    * @param {string} [options.receiver='ws'] Where messages sent via 'send' method will be
    * delivered to, 'ws' for Websocket clients, 'udp' for udp client
    *
    * @example
    * const plugin = new OSC.BridgePlugin({ wsServer: { port: 9912 } })
+   * const osc = new OSC({ plugin: plugin })
+   *
+   * @example <caption>Using an existing HTTP server</caption>
+   * const http = require('http')
+   * const httpServer = http.createServer();
+   * const plugin = new OSC.BridgePlugin({ wsServer: { server: httpServer } })
    * const osc = new OSC({ plugin: plugin })
    */
   constructor(customOptions = {}) {
@@ -153,11 +160,11 @@ export default class BridgePlugin {
       port: options.udpServer.port,
       exclusive: options.udpServer.exclusive,
     }, () => {
+      let wsServerOptions = {};
+      if (options.wsServer.server) wsServerOptions.server = options.wsServer.server;
+      else wsServerOptions = options.wsServer;
       // bind Websocket server
-      this.websocket = new WebSocketServer({
-        host: options.wsServer.host,
-        port: options.wsServer.port,
-      })
+      this.websocket = new WebSocketServer(wsServerOptions)
       this.websocket.binaryType = 'arraybuffer'
 
       // register Websocket events

--- a/src/plugin/wsserver.js
+++ b/src/plugin/wsserver.js
@@ -31,12 +31,18 @@ export default class WebsocketServerPlugin {
    * @param {object} [options] Custom options
    * @param {string} [options.host='localhost'] Hostname of Websocket server
    * @param {number} [options.port=8080] Port of Websocket server
+   * @param {http.Server|https.Server} [options.server] Optional: a pre-created Node.js HTTP/S server to be used instead of creating a new one
    *
    * @example
    * const plugin = new OSC.WebsocketServerPlugin({ port: 9912 })
    * const osc = new OSC({ plugin: plugin })
    *
    * osc.open() // start server
+   * @example <caption>Using an existing HTTP server</caption>
+   * const http = require('http')
+   * const httpServer = http.createServer();
+   * const plugin = new OSC.WebsocketServerPlugin({ server: httpServer })
+   * const osc = new OSC({ plugin: plugin })
    */
   constructor(customOptions) {
     if (!WebSocketServer) {
@@ -107,7 +113,12 @@ export default class WebsocketServerPlugin {
     }
 
     // create websocket server
-    this.socket = new WebSocketServer({ host, port })
+    if (options.server) {
+        this.socket = new WebSocketServer({ server: options.server })
+    } else {
+        this.socket = new WebSocketServer({ host, port })
+    }
+
     this.socket.binaryType = 'arraybuffer'
     this.socketStatus = STATUS.IS_CONNECTING
 


### PR DESCRIPTION
Addressing issue #43 
This PR makes it possible to pass an existing server when initializing BridgePlugin, so that Express and OSC can work together on the same server.
I made the changes also to WebSocketServer Plugin, but that is not tested (I've only used Bridge so far).

Usage example:
```
  // Create a web server to serve files and listen to WebSocket connections
  const app = express();
  app.use(express.static('www'));
  const server = http.createServer(app);

  const osc = new OSC({ plugin: new OSC.BridgePlugin({
    udpServer: { port: 57100 },
    udpClient: { port: 57120 },
    wsServer: {  server }, // here we pass our HTTP server to OSC
  })});
  osc.open();

  // start http server
  server.listen(process.env.port || 8081);
```