### PR TITLE
Websocket Subprotocol support for wsclient plugin

### DIFF
--- a/src/plugin/wsclient.js
+++ b/src/plugin/wsclient.js
@@ -22,7 +22,7 @@ const defaultOptions = {
   host: 'localhost',
   port: 8080,
   secure: false,
-  subProtocol: ''
+  protocol: ''
 }
 
 /**
@@ -36,7 +36,7 @@ export default class WebsocketClientPlugin {
    * @param {string} [options.host='localhost'] Hostname of Websocket server
    * @param {number} [options.port=8080] Port of Websocket server
    * @param {boolean} [options.secure=false] Use wss:// for secure connections
-   * @param {string|array} [options.subProtocol=''] Subprotocol of Websocket server
+   * @param {string|array} [options.protocol=''] Subprotocol of Websocket server
    *
    * @example
    * const plugin = new OSC.WebsocketClientPlugin({ port: 9912 })
@@ -95,11 +95,11 @@ export default class WebsocketClientPlugin {
    * @param {string} [customOptions.host] Hostname of Websocket server
    * @param {number} [customOptions.port] Port of Websocket server
    * @param {boolean} [customOptions.secure] Use wss:// for secure connections
-   * @param {string|array} [options.subProtocol] Subprotocol of Websocket server
+   * @param {string|array} [options.protocol] Subprotocol of Websocket server
    */
   open(customOptions = {}) {
     const options = { ...this.options, ...customOptions }
-    const { port, host, secure, subProtocol } = options
+    const { port, host, secure, protocol } = options
 
     // close socket when already given
     if (this.socket) {
@@ -107,15 +107,15 @@ export default class WebsocketClientPlugin {
     }
 
     // create websocket client
-    const protocol = secure ? 'wss' : 'ws'
+    const scheme = secure ? 'wss' : 'ws'
     const rinfo = {
       address: host,
-      family: protocol,
+      family: scheme,
       port,
       size: 0,
     }
 
-    this.socket = new WebSocket(`${protocol}://${host}:${port}`, !!subProtocol && subProtocol)
+    this.socket = new WebSocket(`${scheme}://${host}:${port}`, !!protocol && protocol)
     this.socket.binaryType = 'arraybuffer'
     this.socketStatus = STATUS.IS_CONNECTING
 

--- a/src/plugin/wsclient.js
+++ b/src/plugin/wsclient.js
@@ -22,6 +22,7 @@ const defaultOptions = {
   host: 'localhost',
   port: 8080,
   secure: false,
+  subProtocol: ''
 }
 
 /**
@@ -35,6 +36,7 @@ export default class WebsocketClientPlugin {
    * @param {string} [options.host='localhost'] Hostname of Websocket server
    * @param {number} [options.port=8080] Port of Websocket server
    * @param {boolean} [options.secure=false] Use wss:// for secure connections
+   * @param {string|array} [options.subProtocol=''] Subprotocol of Websocket server
    *
    * @example
    * const plugin = new OSC.WebsocketClientPlugin({ port: 9912 })
@@ -93,10 +95,11 @@ export default class WebsocketClientPlugin {
    * @param {string} [customOptions.host] Hostname of Websocket server
    * @param {number} [customOptions.port] Port of Websocket server
    * @param {boolean} [customOptions.secure] Use wss:// for secure connections
+   * @param {string|array} [options.subProtocol] Subprotocol of Websocket server
    */
   open(customOptions = {}) {
     const options = { ...this.options, ...customOptions }
-    const { port, host, secure } = options
+    const { port, host, secure, subProtocol } = options
 
     // close socket when already given
     if (this.socket) {
@@ -112,7 +115,7 @@ export default class WebsocketClientPlugin {
       size: 0,
     }
 
-    this.socket = new WebSocket(`${protocol}://${host}:${port}`)
+    this.socket = new WebSocket(`${protocol}://${host}:${port}`, !!subProtocol && subProtocol)
     this.socket.binaryType = 'arraybuffer'
     this.socketStatus = STATUS.IS_CONNECTING
 


### PR DESCRIPTION
[Browser Websockets](https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API/Writing_WebSocket_client_applications) as well as [ws for Node.js](https://github.com/websockets/ws/blob/master/doc/ws.md) support targeting 'sub-protocols' in a websocket connection. 

This PR simply adds `subProtocol` to the options object for the ws-client plugin. 

Browser Websockets and ws API both call this argument `protocols`. This clashes softly with the naming of the 'ws' and 'wss' protocol inside this library - that's the reason I chose the naming `subProtocol`. Not sure about this decision to be honest.