### PR TITLE
Type declarations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "osc-js",
       "version": "2.3.2",
       "license": "MIT",
       "dependencies": {
@@ -29,7 +28,8 @@
         "mocha": "9.2.2",
         "rollup": "2.70.1",
         "rollup-plugin-cleanup": "3.2.1",
-        "rollup-plugin-terser": "7.0.2"
+        "rollup-plugin-terser": "7.0.2",
+        "typescript": "^4.7.4"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -6569,6 +6569,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/typescript": {
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
@@ -11924,6 +11937,12 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true
+    },
+    "typescript": {
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
       "dev": true
     },
     "unbox-primitive": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,12 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "osc-js",
       "version": "2.3.2",
       "license": "MIT",
       "dependencies": {
+        "http": "^0.0.1-security",
+        "https": "^1.0.0",
         "ws": "^8.5.0"
       },
       "devDependencies": {
@@ -4319,6 +4322,11 @@
         "readable-stream": "^3.1.1"
       }
     },
+    "node_modules/http": {
+      "version": "0.0.1-security",
+      "resolved": "https://registry.npmjs.org/http/-/http-0.0.1-security.tgz",
+      "integrity": "sha512-RnDvP10Ty9FxqOtPZuxtebw1j4L/WiqNMDtuc1YMH1XQm5TgDRaR1G9u8upL6KD1bXHSp9eSXo/ED+8Q7FAr+g=="
+    },
     "node_modules/http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -4334,6 +4342,11 @@
         "node": ">=0.8",
         "npm": ">=1.3.7"
       }
+    },
+    "node_modules/https": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/https/-/https-1.0.0.tgz",
+      "integrity": "sha512-4EC57ddXrkaF0x83Oj8sM6SLQHAWXw90Skqu2M4AEWENZ3F02dFJE/GARA8igO79tcgYqGrD7ae4f5L3um2lgg=="
     },
     "node_modules/ice-cap": {
       "version": "0.0.4",
@@ -10238,6 +10251,11 @@
         "readable-stream": "^3.1.1"
       }
     },
+    "http": {
+      "version": "0.0.1-security",
+      "resolved": "https://registry.npmjs.org/http/-/http-0.0.1-security.tgz",
+      "integrity": "sha512-RnDvP10Ty9FxqOtPZuxtebw1j4L/WiqNMDtuc1YMH1XQm5TgDRaR1G9u8upL6KD1bXHSp9eSXo/ED+8Q7FAr+g=="
+    },
     "http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -10249,6 +10267,11 @@
         "jsprim": "^1.2.2",
         "sshpk": "^1.7.0"
       }
+    },
+    "https": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/https/-/https-1.0.0.tgz",
+      "integrity": "sha512-4EC57ddXrkaF0x83Oj8sM6SLQHAWXw90Skqu2M4AEWENZ3F02dFJE/GARA8igO79tcgYqGrD7ae4f5L3um2lgg=="
     },
     "ice-cap": {
       "version": "0.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,6 @@
       "version": "2.3.2",
       "license": "MIT",
       "dependencies": {
-        "http": "^0.0.1-security",
-        "https": "^1.0.0",
         "ws": "^8.5.0"
       },
       "devDependencies": {
@@ -28,6 +26,8 @@
         "eslint": "8.13.0",
         "eslint-config-airbnb-base": "15.0.0",
         "eslint-plugin-import": "2.26.0",
+        "http": "^0.0.1-security",
+        "https": "^1.0.0",
         "mocha": "9.2.2",
         "rollup": "2.70.1",
         "rollup-plugin-cleanup": "3.2.1",
@@ -4325,7 +4325,8 @@
     "node_modules/http": {
       "version": "0.0.1-security",
       "resolved": "https://registry.npmjs.org/http/-/http-0.0.1-security.tgz",
-      "integrity": "sha512-RnDvP10Ty9FxqOtPZuxtebw1j4L/WiqNMDtuc1YMH1XQm5TgDRaR1G9u8upL6KD1bXHSp9eSXo/ED+8Q7FAr+g=="
+      "integrity": "sha512-RnDvP10Ty9FxqOtPZuxtebw1j4L/WiqNMDtuc1YMH1XQm5TgDRaR1G9u8upL6KD1bXHSp9eSXo/ED+8Q7FAr+g==",
+      "dev": true
     },
     "node_modules/http-signature": {
       "version": "1.2.0",
@@ -4346,7 +4347,8 @@
     "node_modules/https": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/https/-/https-1.0.0.tgz",
-      "integrity": "sha512-4EC57ddXrkaF0x83Oj8sM6SLQHAWXw90Skqu2M4AEWENZ3F02dFJE/GARA8igO79tcgYqGrD7ae4f5L3um2lgg=="
+      "integrity": "sha512-4EC57ddXrkaF0x83Oj8sM6SLQHAWXw90Skqu2M4AEWENZ3F02dFJE/GARA8igO79tcgYqGrD7ae4f5L3um2lgg==",
+      "dev": true
     },
     "node_modules/ice-cap": {
       "version": "0.0.4",
@@ -10254,7 +10256,8 @@
     "http": {
       "version": "0.0.1-security",
       "resolved": "https://registry.npmjs.org/http/-/http-0.0.1-security.tgz",
-      "integrity": "sha512-RnDvP10Ty9FxqOtPZuxtebw1j4L/WiqNMDtuc1YMH1XQm5TgDRaR1G9u8upL6KD1bXHSp9eSXo/ED+8Q7FAr+g=="
+      "integrity": "sha512-RnDvP10Ty9FxqOtPZuxtebw1j4L/WiqNMDtuc1YMH1XQm5TgDRaR1G9u8upL6KD1bXHSp9eSXo/ED+8Q7FAr+g==",
+      "dev": true
     },
     "http-signature": {
       "version": "1.2.0",
@@ -10271,7 +10274,8 @@
     "https": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/https/-/https-1.0.0.tgz",
-      "integrity": "sha512-4EC57ddXrkaF0x83Oj8sM6SLQHAWXw90Skqu2M4AEWENZ3F02dFJE/GARA8igO79tcgYqGrD7ae4f5L3um2lgg=="
+      "integrity": "sha512-4EC57ddXrkaF0x83Oj8sM6SLQHAWXw90Skqu2M4AEWENZ3F02dFJE/GARA8igO79tcgYqGrD7ae4f5L3um2lgg==",
+      "dev": true
     },
     "ice-cap": {
       "version": "0.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "mocha": "9.2.2",
         "rollup": "2.70.1",
         "rollup-plugin-cleanup": "3.2.1",
+        "rollup-plugin-dts": "^4.2.2",
         "rollup-plugin-terser": "7.0.2",
         "typescript": "^4.7.4"
       }
@@ -6052,6 +6053,40 @@
         "rollup": ">=2.0"
       }
     },
+    "node_modules/rollup-plugin-dts": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-dts/-/rollup-plugin-dts-4.2.2.tgz",
+      "integrity": "sha512-A3g6Rogyko/PXeKoUlkjxkP++8UDVpgA7C+Tdl77Xj4fgEaIjPSnxRmR53EzvoYy97VMVwLAOcWJudaVAuxneQ==",
+      "dev": true,
+      "dependencies": {
+        "magic-string": "^0.26.1"
+      },
+      "engines": {
+        "node": ">=v12.22.11"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Swatinem"
+      },
+      "optionalDependencies": {
+        "@babel/code-frame": "^7.16.7"
+      },
+      "peerDependencies": {
+        "rollup": "^2.55",
+        "typescript": "^4.1"
+      }
+    },
+    "node_modules/rollup-plugin-dts/node_modules/magic-string": {
+      "version": "0.26.2",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.2.tgz",
+      "integrity": "sha512-NzzlXpclt5zAbmo6h6jNc8zl2gNRGHvmsZW4IvZhTC4W7k4OlLP+S5YLussa/r3ixNT66KOQfNORlXHSOy/X4A==",
+      "dev": true,
+      "dependencies": {
+        "sourcemap-codec": "^1.4.8"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/rollup-plugin-terser": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz",
@@ -11535,6 +11570,27 @@
       "requires": {
         "js-cleanup": "^1.2.0",
         "rollup-pluginutils": "^2.8.2"
+      }
+    },
+    "rollup-plugin-dts": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-dts/-/rollup-plugin-dts-4.2.2.tgz",
+      "integrity": "sha512-A3g6Rogyko/PXeKoUlkjxkP++8UDVpgA7C+Tdl77Xj4fgEaIjPSnxRmR53EzvoYy97VMVwLAOcWJudaVAuxneQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.16.7",
+        "magic-string": "^0.26.1"
+      },
+      "dependencies": {
+        "magic-string": {
+          "version": "0.26.2",
+          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.2.tgz",
+          "integrity": "sha512-NzzlXpclt5zAbmo6h6jNc8zl2gNRGHvmsZW4IvZhTC4W7k4OlLP+S5YLussa/r3ixNT66KOQfNORlXHSOy/X4A==",
+          "dev": true,
+          "requires": {
+            "sourcemap-codec": "^1.4.8"
+          }
+        }
       }
     },
     "rollup-plugin-terser": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "browser": "lib/osc.min.js",
   "scripts": {
     "build": "rollup -c",
+    "build:types": "tsc",
     "docs": "esdoc",
     "lint": "eslint rollup.config.js src/** test/**",
     "test": "mocha test/** --require @babel/register --exit",
@@ -53,7 +54,8 @@
     "mocha": "9.2.2",
     "rollup": "2.70.1",
     "rollup-plugin-cleanup": "3.2.1",
-    "rollup-plugin-terser": "7.0.2"
+    "rollup-plugin-terser": "7.0.2",
+    "typescript": "^4.7.4"
   },
   "dependencies": {
     "ws": "^8.5.0"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   "types": "lib/osc.d.ts",
   "scripts": {
     "build": "rollup -c",
-    "build:types": "tsc",
     "docs": "esdoc",
     "lint": "eslint rollup.config.js src/** test/**",
     "test": "mocha test/** --require @babel/register --exit",
@@ -52,6 +51,8 @@
     "eslint": "8.13.0",
     "eslint-config-airbnb-base": "15.0.0",
     "eslint-plugin-import": "2.26.0",
+    "http": "^0.0.1-security",
+    "https": "^1.0.0",
     "mocha": "9.2.2",
     "rollup": "2.70.1",
     "rollup-plugin-cleanup": "3.2.1",
@@ -60,8 +61,6 @@
     "typescript": "^4.7.4"
   },
   "dependencies": {
-    "http": "^0.0.1-security",
-    "https": "^1.0.0",
     "ws": "^8.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "OSC library for Node.js and the browser, with customizable Plugin API for WebSocket, UDP or bridge networking",
   "main": "lib/osc.js",
   "browser": "lib/osc.min.js",
+  "types": "lib/osc.d.ts",
   "scripts": {
     "build": "rollup -c",
     "build:types": "tsc",
@@ -54,6 +55,7 @@
     "mocha": "9.2.2",
     "rollup": "2.70.1",
     "rollup-plugin-cleanup": "3.2.1",
+    "rollup-plugin-dts": "^4.2.2",
     "rollup-plugin-terser": "7.0.2",
     "typescript": "^4.7.4"
   },

--- a/package.json
+++ b/package.json
@@ -60,6 +60,8 @@
     "typescript": "^4.7.4"
   },
   "dependencies": {
+    "http": "^0.0.1-security",
+    "https": "^1.0.0",
     "ws": "^8.5.0"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,7 @@
 import alias from '@rollup/plugin-alias'
 import babel from '@rollup/plugin-babel'
 import cleanup from 'rollup-plugin-cleanup'
+import dts from 'rollup-plugin-dts'
 import { terser } from 'rollup-plugin-terser'
 
 function rollupPlugins({ isBrowser = false } = {}) {
@@ -48,4 +49,9 @@ export default [
     file: 'lib/osc.min.js',
     isBrowser: true,
   }),
+  {
+    input: './src/osc.js',
+    output: [{ file: 'lib/osc.d.ts', format: 'es' }],
+    plugins: [dts()],
+  },
 ]

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -53,5 +53,6 @@ export default [
     input: './src/osc.js',
     output: [{ file: 'lib/osc.d.ts', format: 'es' }],
     plugins: [dts()],
+    external: ['http', 'https'],
   },
 ]

--- a/src/atomic/constant.js
+++ b/src/atomic/constant.js
@@ -10,6 +10,7 @@ export const VALUE_FALSE = false
 
 /**
  * Extended type without data representing "None"
+ * @type {null}
  */
 export const VALUE_NONE = null
 

--- a/src/atomic/string.js
+++ b/src/atomic/string.js
@@ -15,7 +15,7 @@ const STR_ENCODING = 'utf-8'
 
 /**
  * Helper method to decode a string using different methods depending on environment
- * @param {array} charCodes Array of char codes
+ * @param {number[]} charCodes Array of char codes
  * @return {string} Decoded string
  */
 function charCodesToString(charCodes) {

--- a/src/bundle.js
+++ b/src/bundle.js
@@ -16,7 +16,7 @@ export const BUNDLE_TAG = '#bundle'
 export default class Bundle {
   /**
    * Create a Bundle instance
-   * @param {...*} [args] Timetag and elements. See examples for options
+   * @param {...*} args Timetag and elements. See examples for options
    *
    * @example
    * const bundle = new Bundle(new Date() + 500)

--- a/src/common/helpers.js
+++ b/src/common/helpers.js
@@ -37,7 +37,7 @@ export function typeTag(item) {
 
 /**
  * Sanitizes an OSC-ready Address Pattern
- * @param {array|string} obj Address as string or array of strings
+ * @param {string[]|string} obj Address as string or array of strings
  * @return {string} Corrected address string
  *
  * @example

--- a/src/external/ws.js
+++ b/src/external/ws.js
@@ -1,18 +1,25 @@
 // This file gets used instead of the `ws` package during rollup builds
 // targeting browser environments.
-let ws
-
-if (typeof WebSocket !== 'undefined') {
-  ws = WebSocket
-} else if (typeof MozWebSocket !== 'undefined') {
-  ws = MozWebSocket
-} else if (typeof global !== 'undefined') {
-  ws = global.WebSocket || global.MozWebSocket
-} else if (typeof window !== 'undefined') {
-  ws = window.WebSocket || window.MozWebSocket
-} else if (typeof self !== 'undefined') {
-  ws = self.WebSocket || self.MozWebSocket
+/* eslint-disable no-undef */
+/* eslint-disable no-restricted-globals */
+function fillWs() {
+  if (typeof WebSocket !== 'undefined') {
+    return WebSocket
+  } else if (typeof MozWebSocket !== 'undefined') {
+    return MozWebSocket
+  } else if (typeof global !== 'undefined') {
+    return global.WebSocket || global.MozWebSocket
+  } else if (typeof window !== 'undefined') {
+    return window.WebSocket || window.MozWebSocket
+  } else if (typeof self !== 'undefined') {
+    return self.WebSocket || self.MozWebSocket
+  }
+  return undefined
 }
+/* eslint-enable no-undef */
+/* eslint-enable no-restricted-globals */
+
+const ws = fillWs()
 
 /**
  * Do not export server for browser environments.

--- a/src/message.js
+++ b/src/message.js
@@ -20,7 +20,7 @@ import {
 /**
  * A TypedMessage consists of an OSC address and an optional array of typed OSC arguments.
  *
- * ## Supported types
+ * @typedef {('i'|'f'|'s'|'b'|'h'|'t'|'d'|'T'|'F'|'N'|'I')} MessageArgType
  *
  * - `i` - int32
  * - `f` - float32
@@ -34,12 +34,22 @@ import {
  * - `N` - Nil (no argument data)
  * - `I` - Infinitum (no argument data)
  *
+ * @typedef {(number|string|Blob|VALUE_TRUE|VALUE_FALSE|VALUE_NONE|VALUE_INFINITY)} MessageArgValue
+ *
+ * @typedef {object} MessageArgObject
+ * @property {MessageArgType} type
+ * @property {MessageArgValue} value
+ *
+ * @example
+ * const messageArgObject = {
+ *   type: 'i', value: 123
+ * }
  */
 export class TypedMessage {
   /**
    * Create a TypedMessage instance
-   * @param {array|string} address Address
-   * @param {array} args Arguments
+   * @param {string[]|string} address Address
+   * @param {MessageArgValue[]} args Arguments
    *
    * @example
    * const message = new TypedMessage(['test', 'path'])
@@ -64,7 +74,7 @@ export class TypedMessage {
     this.address = ''
     /** @type {string} types */
     this.types = ''
-    /** @type {array} args */
+    /** @type {MessageArgValue[]} args */
     this.args = []
 
     if (!isUndefined(address)) {
@@ -84,8 +94,8 @@ export class TypedMessage {
 
   /**
    * Add an OSC Atomic Data Type to the list of elements
-   * @param {string} type
-   * @param {*} item
+   * @param {MessageArgType} type
+   * @param {MessageArgObject} item
    */
   add(type, item) {
     if (isUndefined(type)) {
@@ -251,8 +261,8 @@ export class TypedMessage {
 export default class Message extends TypedMessage {
   /**
    * Create a Message instance
-   * @param {array|string} args Address
-   * @param {...*} args OSC Atomic Data Types
+   * @param {string[]|string} address Address
+   * @param {...MessageArgObject} args OSC Atomic Data Types
    *
    * @example
    * const message = new Message(['test', 'path'], 50, 100.52, 'test')
@@ -260,12 +270,7 @@ export default class Message extends TypedMessage {
    * @example
    * const message = new Message('/test/path', 51.2)
    */
-  constructor(...args) {
-    let address
-    if (args.length > 0) {
-      address = args.shift()
-    }
-
+  constructor(address, ...args) {
     let oscArgs
     if (args.length > 0) {
       if (args[0] instanceof Array) {
@@ -283,7 +288,7 @@ export default class Message extends TypedMessage {
 
   /**
    * Add an OSC Atomic Data Type to the list of elements
-   * @param {*} item
+   * @param {MessageArgObject} item
    */
   add(item) {
     super.add(typeTag(item), item)

--- a/src/message.js
+++ b/src/message.js
@@ -95,7 +95,7 @@ export class TypedMessage {
   /**
    * Add an OSC Atomic Data Type to the list of elements
    * @param {MessageArgType} type
-   * @param {MessageArgObject} item
+   * @param {MessageArgValue} item
    */
   add(type, item) {
     if (isUndefined(type)) {
@@ -262,7 +262,7 @@ export default class Message extends TypedMessage {
   /**
    * Create a Message instance
    * @param {string[]|string} address Address
-   * @param {...MessageArgObject} args OSC Atomic Data Types
+   * @param {...MessageArgValue} args OSC Atomic Data Types
    *
    * @example
    * const message = new Message(['test', 'path'], 50, 100.52, 'test')
@@ -288,7 +288,7 @@ export default class Message extends TypedMessage {
 
   /**
    * Add an OSC Atomic Data Type to the list of elements
-   * @param {MessageArgObject} item
+   * @param {MessageArgValue} item
    */
   add(item) {
     super.add(typeTag(item), item)

--- a/src/message.js
+++ b/src/message.js
@@ -20,7 +20,7 @@ import {
 /**
  * A TypedMessage consists of an OSC address and an optional array of typed OSC arguments.
  *
- * @typedef {('i'|'f'|'s'|'b'|'h'|'t'|'d'|'T'|'F'|'N'|'I')} MessageArgType
+ * @typedef {'i'|'f'|'s'|'b'|'h'|'t'|'d'|'T'|'F'|'N'|'I'} MessageArgType
  *
  * - `i` - int32
  * - `f` - float32
@@ -34,7 +34,7 @@ import {
  * - `N` - Nil (no argument data)
  * - `I` - Infinitum (no argument data)
  *
- * @typedef {(number|string|Blob|VALUE_TRUE|VALUE_FALSE|VALUE_NONE|VALUE_INFINITY)} MessageArgValue
+ * @typedef {number|string|Blob|VALUE_TRUE|VALUE_FALSE|VALUE_NONE|VALUE_INFINITY} MessageArgValue
  *
  * @typedef {object} MessageArgObject
  * @property {MessageArgType} type

--- a/src/osc.js
+++ b/src/osc.js
@@ -14,6 +14,7 @@ import DatagramPlugin from './plugin/dgram'
 import BridgePlugin from './plugin/bridge'
 import WebsocketClientPlugin from './plugin/wsclient'
 import WebsocketServerPlugin from './plugin/wsserver'
+import Plugin from './plugin/plugin'
 
 /**
  * Default options
@@ -212,7 +213,7 @@ class OSC {
   /**
    * Send an OSC Packet, Bundle or Message. This method is used by plugins
    * and is not available without (see Plugin API for more information)
-   * @param {Packet|Bundle|Message} packet OSC Packet, Bundle or Message instance
+   * @param {Packet|Bundle|Message|TypedMessage} packet OSC Packet, Bundle or Message instance
    * @param {object} [options] Custom options
    *
    * @example
@@ -256,6 +257,7 @@ OSC.Message = Message
 OSC.TypedMessage = TypedMessage
 
 // expose plugins
+OSC.Plugin = Plugin
 OSC.DatagramPlugin = DatagramPlugin
 OSC.WebsocketClientPlugin = WebsocketClientPlugin
 OSC.WebsocketServerPlugin = WebsocketServerPlugin

--- a/src/plugin/bridge.js
+++ b/src/plugin/bridge.js
@@ -1,5 +1,6 @@
 import dgram from 'dgram'
 import { WebSocketServer } from 'ws'
+import Plugin from './plugin'
 
 /**
  * Status flags
@@ -53,7 +54,7 @@ function mergeOptions(base, custom) {
  * OSC plugin for setting up communication between a Websocket
  * client and a udp client with a bridge inbetween
  */
-export default class BridgePlugin {
+export default class BridgePlugin extends Plugin {
   /**
    * Create an OSC Bridge instance with given options. Defaults to
    * localhost:41234 for udp server, localhost:41235 for udp client and
@@ -80,7 +81,9 @@ export default class BridgePlugin {
    * const plugin = new OSC.BridgePlugin({ wsServer: { server: httpServer } })
    * const osc = new OSC({ plugin: plugin })
    */
-  constructor(customOptions = {}) {
+  constructor(options = {}) {
+    super()
+
     // `dgram` and `WebSocketServer` get replaced with an undefined value in
     // builds targeting browser environments
     if (!dgram || !WebSocketServer) {
@@ -90,7 +93,7 @@ export default class BridgePlugin {
     /** @type {object} options
      * @private
      */
-    this.options = mergeOptions({}, customOptions)
+    this.options = mergeOptions({}, options)
 
     /**
      * @type {object} websocket

--- a/src/plugin/dgram.js
+++ b/src/plugin/dgram.js
@@ -1,4 +1,5 @@
 import dgram from 'dgram'
+import Plugin from './plugin'
 
 /**
  * Status flags
@@ -59,7 +60,7 @@ function mergeOptions(base, custom) {
  * OSC plugin for simple OSC messaging via udp client
  * and udp server
  */
-export default class DatagramPlugin {
+export default class DatagramPlugin extends Plugin {
   /**
    * Create an OSC Plugin instance with given options. Defaults to
    * localhost:41234 for server and localhost:41235 for client messaging
@@ -75,7 +76,9 @@ export default class DatagramPlugin {
    * const plugin = new OSC.DatagramPlugin({ send: { port: 9912 } })
    * const osc = new OSC({ plugin: plugin })
    */
-  constructor(customOptions = {}) {
+  constructor(options = {}) {
+    super()
+
     // `dgram` gets replaced with an undefined value in builds targeting
     // browser environments
     if (!dgram) {
@@ -86,7 +89,7 @@ export default class DatagramPlugin {
      * @type {object} options
      * @private
      */
-    this.options = mergeOptions({}, customOptions)
+    this.options = mergeOptions({}, options)
 
     /**
      * @type {object} socket

--- a/src/plugin/plugin.js
+++ b/src/plugin/plugin.js
@@ -1,0 +1,58 @@
+// /**
+//  @constructor
+//  @abstract
+//  */
+// const Plugin = () => {
+//   if (this.constructor === Plugin) {
+//   }
+// }
+
+// /**
+// @abstract
+// */
+// Plugin.prototype.close = () => {
+//   throw new Error('Abstract method!')
+// }
+
+export default class Plugin {
+  constructor() {
+    if (this.constructor === Plugin) {
+      throw new Error('Plugin is an abstract class. Please create or use an implementation!')
+    }
+  }
+
+  /**
+   * Returns the current status of the connection
+   * @return {number} Status ID
+   */
+  status() {
+    throw new Error('Abstract method!')
+  }
+
+  /**
+   * Open socket connection. Specifics depend on implementation.
+   * @param {object} [customOptions] Custom options. See implementation specifics.
+   */
+  // eslint-disable-next-line no-unused-vars
+  open(customOptions = {}) {
+    throw new Error('Abstract method!')
+  }
+
+  /**
+   * Close socket connection and anything else used in the implementation.
+   */
+  close() {
+    throw new Error('Abstract method!')
+  }
+
+  /**
+   * Send an OSC Packet, Bundle or Message. Use options here for
+   * custom receiver, otherwise the global options will be taken
+   * @param {Uint8Array} binary Binary representation of OSC Packet
+   * @param {object} [customOptions] Custom options. Specifics depend on implementation.
+   */
+  // eslint-disable-next-line no-unused-vars
+  send(binary, customOptions = {}) {
+    throw new Error('Abstract method!')
+  }
+}

--- a/src/plugin/wsclient.js
+++ b/src/plugin/wsclient.js
@@ -1,4 +1,5 @@
 import WebSocket from 'ws'
+import Plugin from './plugin'
 
 /**
  * Status flags
@@ -26,7 +27,7 @@ const defaultOptions = {
 /**
  * OSC plugin for a Websocket client running in node or browser context
  */
-export default class WebsocketClientPlugin {
+export default class WebsocketClientPlugin extends Plugin {
   /**
    * Create an OSC WebsocketClientPlugin instance with given options.
    * Defaults to *localhost:8080* for connecting to a Websocket server
@@ -34,13 +35,15 @@ export default class WebsocketClientPlugin {
    * @param {string} [options.host='localhost'] Hostname of Websocket server
    * @param {number} [options.port=8080] Port of Websocket server
    * @param {boolean} [options.secure=false] Use wss:// for secure connections
-   * @param {string|array} [options.protocol=''] Subprotocol of Websocket server
+   * @param {string|string[]} [options.protocol=''] Subprotocol of Websocket server
    *
    * @example
    * const plugin = new OSC.WebsocketClientPlugin({ port: 9912 })
    * const osc = new OSC({ plugin: plugin })
    */
-  constructor(customOptions) {
+  constructor(options) {
+    super()
+
     if (!WebSocket) {
       throw new Error('WebsocketClientPlugin can\'t find a WebSocket class')
     }
@@ -49,7 +52,7 @@ export default class WebsocketClientPlugin {
      * @type {object} options
      * @private
      */
-    this.options = { ...defaultOptions, ...customOptions }
+    this.options = { ...defaultOptions, ...options }
 
     /**
      * @type {object} socket
@@ -93,7 +96,7 @@ export default class WebsocketClientPlugin {
    * @param {string} [customOptions.host] Hostname of Websocket server
    * @param {number} [customOptions.port] Port of Websocket server
    * @param {boolean} [customOptions.secure] Use wss:// for secure connections
-   * @param {string|array} [options.protocol] Subprotocol of Websocket server
+   * @param {string|string[]} [options.protocol] Subprotocol of Websocket server
    */
   open(customOptions = {}) {
     const options = { ...this.options, ...customOptions }

--- a/src/plugin/wsserver.js
+++ b/src/plugin/wsserver.js
@@ -1,4 +1,5 @@
 import { WebSocketServer } from 'ws'
+import Plugin from './plugin'
 
 /**
  * Status flags
@@ -22,16 +23,22 @@ const defaultOptions = {
 }
 
 /**
+ * This will import the types for JSDoc/Type declarations without
+ * impacting the runtime
+ * @typedef {(import('http').Server|import('https').Server)} Server
+ */
+
+/**
  * OSC plugin for a Websocket client running in node or browser context
  */
-export default class WebsocketServerPlugin {
+export default class WebsocketServerPlugin extends Plugin {
   /**
    * Create an OSC WebsocketServerPlugin instance with given options.
    * Defaults to *localhost:8080* for the Websocket server
    * @param {object} [options] Custom options
    * @param {string} [options.host='localhost'] Hostname of Websocket server
    * @param {number} [options.port=8080] Port of Websocket server
-   * @param {http.Server|https.Server} [options.server] Use existing Node.js HTTP/S server
+   * @param {Server} [options.server] Use existing Node.js HTTP/S server
    *
    * @example
    * const plugin = new OSC.WebsocketServerPlugin({ port: 9912 })
@@ -44,7 +51,9 @@ export default class WebsocketServerPlugin {
    * const plugin = new OSC.WebsocketServerPlugin({ server: httpServer })
    * const osc = new OSC({ plugin: plugin })
    */
-  constructor(customOptions) {
+  constructor(options) {
+    super()
+
     // `WebSocketServer` gets replaced with an undefined value in builds
     // targeting browser environments
     if (!WebSocketServer) {
@@ -55,7 +64,7 @@ export default class WebsocketServerPlugin {
      * @type {object} options
      * @private
      */
-    this.options = { ...defaultOptions, ...customOptions }
+    this.options = { ...defaultOptions, ...options }
 
     /**
      * @type {object} socket

--- a/src/plugin/wsserver.js
+++ b/src/plugin/wsserver.js
@@ -25,7 +25,7 @@ const defaultOptions = {
 /**
  * This will import the types for JSDoc/Type declarations without
  * impacting the runtime
- * @typedef {(import('http').Server|import('https').Server)} Server
+ * @typedef {import('http').Server|import('https').Server} Server
  */
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    "allowJs": true,
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "outDir": "lib"
+  }
+}


### PR DESCRIPTION
Fixes #55 

I'm working on a project that is using osc-js in a production TypeScript app. I have already made some custom typings in my project but decided to contribute to the repo when I saw your positive indication on issue #55.

I considered making an MR to drop in the custom typings I made, but conveniently the tsc compiler can use your JSDoc comments to generate proper typings. I thought you might appreciate an automated setup more so type files don't have to be maintained by devs and will be updated each time you deploy.

What I have done here is:

1. Add the typescript compiler
2. Configured ts to build only declaration files for you. Conveniently it knows the types based on all your JSDoc comments so thank you for that!
3. Added a rollup plugin that neatly pulls all the public types you would want into one file added to your lib folder (osc.d.ts)
4. Updated some JSDoc types around the codebase to work better for the type generator.
5. Added an "abstract" class called Plugin. This fixed an issue in the JSDoc that was referencing a built-in Browser Plugin class. This was leading to some typescript errors when calling `new OSC()` because it was expecting you to send a browser Plugin type rather than one of the ones from osc-js.
   * If you don't like this an alternative would be to change the type to `@param {WebsocketClientPlugin|WebsocketServerPlugin|BridgePlugin|DatagramPlugin}` or I think there is a duck-typing thing we can do with JSDoc to make a typedef called `PluginLike` 

Let me know what you think about this. I worked a little too hard on it honestly, should have asked first 😅 If you aren't a big fan, I can submit my custom typings to the DefinitelyTyped repo so TS gives will be inclined to use your lib.