### PR TITLE
fix timestamp calculation

### DIFF
--- a/src/atomic/timetag.js
+++ b/src/atomic/timetag.js
@@ -52,7 +52,7 @@ export class Timetag {
     }
 
     seconds = this.seconds - SECONDS_70_YEARS
-    return (seconds + Math.round(this.fractions / TWO_POWER_32)) * 1000
+    return Math.round((seconds + timetag.fractions / TWO_POWER_32) * 1000)
   }
 }
 

--- a/src/atomic/timetag.js
+++ b/src/atomic/timetag.js
@@ -52,7 +52,7 @@ export class Timetag {
     }
 
     seconds = this.seconds - SECONDS_70_YEARS
-    return Math.round((seconds + timetag.fractions / TWO_POWER_32) * 1000)
+    return Math.round((seconds + this.fractions / TWO_POWER_32) * 1000)
   }
 }
 


### PR DESCRIPTION
There was an error in the calculation of the return value. ```Math.round()``` was at the wrong place as ```Math.round(this.fractions / TWO_POWER_32)``` only has a value of 0 or 1.