### PR TITLE
Create Packet from bundleItem to fix wrong type when dispatching.

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -84,7 +84,7 @@ export default class EventHandler {
           if (bundle.timetag.value.timestamp() < bundleItem.timetag.value.timestamp()) {
             throw new Error('OSC Bundle timestamp is older than the timestamp of enclosed Bundles')
           }
-          return this.dispatch(bundleItem)
+          return this.dispatch(new Packet(bundleItem))
         } else if (bundleItem instanceof Message) {
           const message = bundleItem
           return this.notify(


### PR DESCRIPTION
This fixes the error when a OSC message with nested bundles could not be processed because dispatch would be called passing a Bundle instead of Packet.

Fixes #76 . 